### PR TITLE
Added "Alias" property to BusinessResponse model

### DIFF
--- a/Source/Yelp.Api/Models/Business.cs
+++ b/Source/Yelp.Api/Models/Business.cs
@@ -45,6 +45,9 @@ namespace Yelp.Api.Models
 
         [JsonProperty("id")]
         public string Id { get; set; }
+        
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
 
         [JsonProperty("review_count")]
         public int ReviewCount { get; set; }


### PR DESCRIPTION
The yelp JSON model returns an "alias" property that is missing from the C# BusinessResponse model.